### PR TITLE
Introduce the `keepOriginal` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ class UsersController {
 
 > NOTE: You should `await` the operation `ResponsiveAttachment.fromFile(coverImage)` as the uploaded image is being temporarily persisted during the `fromFile` operation. This is a bit different from the approach of the `attachment-lite` add-on. In order to offer a uniform syntax you are required to also await the method `ResponsiveAttachment.fromBuffer`.
 
-The `ResponsiveAttachment.fromFile` or `ResponsiveAttachment.fromBuffer` static method creates an instance of the ResponsiveAttachment class from the uploaded image or provider buffer. When you persist the model to the database, the `adonis-responsive-attachment` add-on will write the file or buffer to the disk and generate optimised responsive images and thumbnails from the original image.
+The `ResponsiveAttachment.fromFile` or `ResponsiveAttachment.fromBuffer` static method creates an instance of the `ResponsiveAttachment` class from the uploaded image or provider buffer. When you persist the model to the database, the `adonis-responsive-attachment` add-on will write the file or buffer to the disk and generate optimised responsive images and thumbnails from the original image.
 
 ### Handling updates
 You can update the property with a newly image, and the package will take care of removing the old images and generating and persisting new responsive images.
@@ -224,6 +224,7 @@ The `responsiveAttachment` decorator accepts the following options:
 7. `responsiveDimensions` - boolean,
 8. `preComputeUrls` - boolean,
 9. `disableThumbnail` - boolean.
+10. `keepOriginal` - boolean.
 
 Let's discuss these options
 
@@ -399,6 +400,31 @@ post.coverImage.breakpoints.medium.name // exists
 post.coverImage.breakpoints.large.name // exists
 
 post.coverImage.breakpoints.thumbnail // does not exist
+```
+
+### 10. The `keepOriginal` Option
+
+The `keepOriginal` option allows you to decide whether to keep the original uploaded image or not. If you do not have any need for the original image in the future, there should be no need to keep it. By default `keepOriginal` is `true` but you can disable it by setting it to `false`.
+
+```ts
+class Post extends BaseModel {
+  @responsiveAttachment({keepOriginal: false})
+  public coverImage: ResponsiveAttachmentContract
+}
+
+const post = await Post.findOrFail(1)
+post.coverImage.name // does not exist
+post.coverImage.hash // does not exist
+post.coverImage.width // does not exist
+post.coverImage.format // does not exist
+post.coverImage.height // does not exist
+post.coverImage.extname // does not exist
+post.coverImage.mimeType // does not exist
+
+post.coverImage.breakpoints.small.name // exists
+post.coverImage.breakpoints.medium.name // exists
+post.coverImage.breakpoints.large.name // exists
+post.coverImage.breakpoints.thumbnail.name // exists
 ```
 
 ## Generating URLs

--- a/adonis-typings/attachment.ts
+++ b/adonis-typings/attachment.ts
@@ -31,6 +31,7 @@ declare module '@ioc:Adonis/Addons/ResponsiveAttachment' {
   export type AttachmentOptions = {
     disk?: keyof DisksList
     folder?: string
+    keepOriginal?: boolean
     breakpoints?: Breakpoints
     forceFormat?: 'jpeg' | 'png' | 'webp' | 'avif' | 'tiff'
     optimizeSize?: boolean
@@ -46,60 +47,60 @@ declare module '@ioc:Adonis/Addons/ResponsiveAttachment' {
     /**
      * The name is available only when "isPersisted" is true.
      */
-    name: string
+    name?: string
 
     /**
      * The url is available only when "isPersisted" is true.
      */
-    url: string | null
+    url?: string
 
     /**
      * The file size in bytes
      */
-    size: number
+    size?: number
 
     /**
      * The file extname. Inferred from the BodyParser file extname
      * property
      */
-    extname: string
+    extname?: string
 
     /**
      * The file mimetype.
      */
-    mimeType: string
+    mimeType?: string
 
     /**
      * The hash string of the image
      */
-    hash: string
+    hash?: string
 
     /**
      * The width of the image
      */
-    width: number
+    width?: number
 
     /**
      * The height of the image
      */
-    height: number
+    height?: number
 
     /**
      * The format of the image
      */
-    format: AttachmentOptions['forceFormat']
+    format?: AttachmentOptions['forceFormat']
 
     /**
      * The breakpoints object for the image
      */
-    breakpoints: ImageBreakpoints | undefined
+    breakpoints?: Record<keyof ImageBreakpoints, ImageInfo>
   }
 
   /**
    * Attachment class represents an attachment data type
    * for Lucid models
    */
-  export interface ResponsiveAttachmentContract {
+  export interface ResponsiveAttachmentContract extends ImageAttributes {
     /**
      * The breakpoint objects
      */
@@ -157,12 +158,12 @@ declare module '@ioc:Adonis/Addons/ResponsiveAttachment' {
      */
     getUrls(
       signingOptions?: ContentHeaders & { expiresIn?: string | number }
-    ): Promise<UrlRecords | null>
+    ): Promise<UrlRecords | undefined>
 
     /**
      * Attachment attributes
      */
-    toJSON(): (AttachmentAttributes & { url?: string | null }) | null
+    toJSON(): (AttachmentAttributes & { url?: string | undefined }) | null
   }
 
   /**

--- a/adonis-typings/images.ts
+++ b/adonis-typings/images.ts
@@ -18,11 +18,11 @@ declare module '@ioc:Adonis/Addons/ResponsiveAttachment' {
   export type ImageInfo = {
     name?: string
     hash?: string
-    extname: string
-    mimeType: string
-    size: number
-    path?: string | null
-    buffer?: Buffer | null
+    extname?: string
+    mimeType?: string
+    size?: number
+    path?: string
+    buffer?: Buffer
     width?: number
     height?: number
     /**
@@ -30,8 +30,8 @@ declare module '@ioc:Adonis/Addons/ResponsiveAttachment' {
      * to different file types/formats
      */
     format?: AttachmentOptions['forceFormat']
-    breakpoints?: ImageBreakpoints | null
-    url?: string | null
+    breakpoints?: Record<keyof ImageBreakpoints, ImageInfo>
+    url?: string
   }
 
   export type ImageData = {
@@ -56,8 +56,8 @@ declare module '@ioc:Adonis/Addons/ResponsiveAttachment' {
   }
 
   export type ImageDimensions = {
-    width: number | undefined
-    height: number | undefined
+    width?: number
+    height?: number
   }
 
   export type BreakpointFormat = ({ key: keyof ImageBreakpoints } & { file: ImageInfo }) | null
@@ -70,12 +70,12 @@ declare module '@ioc:Adonis/Addons/ResponsiveAttachment' {
   }
 
   export type UrlRecords = {
-    url: string | null
-    breakpoints: Record<keyof ImageBreakpoints, { url: string | null }>
+    url?: string
+    breakpoints?: Record<keyof ImageBreakpoints, { url?: string }>
   }
 
   export type NameRecords = {
-    name: string
-    breakpoints: Record<keyof ImageBreakpoints, { name: string }>
+    name?: string
+    breakpoints?: Record<keyof ImageBreakpoints, { name?: string }>
   }
 }

--- a/src/Attachment/decorator.ts
+++ b/src/Attachment/decorator.ts
@@ -218,6 +218,7 @@ export const responsiveAttachment: ResponsiveAttachmentDecorator = (options) => 
     const {
       disk,
       folder,
+      keepOriginal = true,
       preComputeUrls = false,
       breakpoints = DEFAULT_BREAKPOINTS,
       forceFormat,
@@ -242,6 +243,7 @@ export const responsiveAttachment: ResponsiveAttachmentDecorator = (options) => 
       options: {
         disk,
         folder,
+        keepOriginal,
         preComputeUrls,
         breakpoints,
         forceFormat,

--- a/src/Helpers/ImageManipulationHelper.ts
+++ b/src/Helpers/ImageManipulationHelper.ts
@@ -141,7 +141,7 @@ export const generateName = function ({
   prefix,
   options,
 }: {
-  extname: string
+  extname?: string
   hash?: string
   prefix?: keyof ImageBreakpoints | 'original'
   options?: AttachmentOptions

--- a/test/attachment-decorator.spec.ts
+++ b/test/attachment-decorator.spec.ts
@@ -24,7 +24,7 @@ import { readFile } from 'fs/promises'
 
 let app: ApplicationContract
 
-type AttachmentBody = { body: { avatar: ResponsiveAttachment } }
+type AttachmentBody = { body: { avatar: ResponsiveAttachmentContract } }
 
 test.group('@responsiveAttachment | insert', (group) => {
   group.before(async () => {
@@ -87,21 +87,21 @@ test.group('@responsiveAttachment | insert', (group) => {
     assert.deepEqual(users[0].avatar?.toJSON(), body.avatar)
 
     assert.isTrue(await Drive.exists(body.avatar.name!))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
 
     assert.notExists(body.avatar.url)
-    assert.notExists(body.avatar.breakpoints!.large.url)
-    assert.notExists(body.avatar.breakpoints!.medium.url)
-    assert.notExists(body.avatar.breakpoints!.small.url)
-    assert.notExists(body.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(body.avatar.breakpoints?.large.url)
+    assert.notExists(body.avatar.breakpoints?.medium.url)
+    assert.notExists(body.avatar.breakpoints?.small.url)
+    assert.notExists(body.avatar.breakpoints?.thumbnail.url)
   })
 
   test('cleanup attachments when save call fails', async (assert) => {
@@ -151,21 +151,21 @@ test.group('@responsiveAttachment | insert', (group) => {
     assert.isNull(users[0].avatar)
 
     assert.isFalse(await Drive.exists(body.avatar.name!))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
 
     assert.notExists(body.avatar.url)
-    assert.notExists(body.avatar.breakpoints!.large.url)
-    assert.notExists(body.avatar.breakpoints!.medium.url)
-    assert.notExists(body.avatar.breakpoints!.small.url)
-    assert.notExists(body.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(body.avatar.breakpoints?.large.url)
+    assert.notExists(body.avatar.breakpoints?.medium.url)
+    assert.notExists(body.avatar.breakpoints?.small.url)
+    assert.notExists(body.avatar.breakpoints?.thumbnail.url)
   })
 })
 
@@ -233,21 +233,21 @@ test.group('@responsiveAttachment | insert with transaction', (group) => {
     assert.deepEqual(users[0].avatar?.toJSON(), body.avatar)
 
     assert.isTrue(await Drive.exists(body.avatar.name!))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
 
     assert.notExists(body.avatar.url)
-    assert.notExists(body.avatar.breakpoints!.large.url)
-    assert.notExists(body.avatar.breakpoints!.medium.url)
-    assert.notExists(body.avatar.breakpoints!.small.url)
-    assert.notExists(body.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(body.avatar.breakpoints?.large.url)
+    assert.notExists(body.avatar.breakpoints?.medium.url)
+    assert.notExists(body.avatar.breakpoints?.small.url)
+    assert.notExists(body.avatar.breakpoints?.thumbnail.url)
   })
 
   test('cleanup attachments when save call fails', async (assert) => {
@@ -302,21 +302,21 @@ test.group('@responsiveAttachment | insert with transaction', (group) => {
     assert.isNull(users[0].avatar)
 
     assert.isFalse(await Drive.exists(body.avatar.name!))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
 
     assert.notExists(body.avatar.url)
-    assert.notExists(body.avatar.breakpoints!.large.url)
-    assert.notExists(body.avatar.breakpoints!.medium.url)
-    assert.notExists(body.avatar.breakpoints!.small.url)
-    assert.notExists(body.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(body.avatar.breakpoints?.large.url)
+    assert.notExists(body.avatar.breakpoints?.medium.url)
+    assert.notExists(body.avatar.breakpoints?.small.url)
+    assert.notExists(body.avatar.breakpoints?.thumbnail.url)
   })
 
   test('cleanup attachments when rollback is called after success', async (assert) => {
@@ -362,16 +362,16 @@ test.group('@responsiveAttachment | insert with transaction', (group) => {
 
     assert.lengthOf(users, 0)
     assert.isFalse(await Drive.exists(body.avatar.name!))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(body.avatar.url)
-    assert.notExists(body.avatar.breakpoints!.large.url)
-    assert.notExists(body.avatar.breakpoints!.medium.url)
-    assert.notExists(body.avatar.breakpoints!.small.url)
-    assert.notExists(body.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(body.avatar.breakpoints?.large.url)
+    assert.notExists(body.avatar.breakpoints?.medium.url)
+    assert.notExists(body.avatar.breakpoints?.small.url)
+    assert.notExists(body.avatar.breakpoints?.thumbnail.url)
   })
 })
 
@@ -438,34 +438,36 @@ test.group('@responsiveAttachment | update', (group) => {
     assert.deepEqual(users[0].avatar?.toJSON(), secondResponse.avatar)
 
     assert.isFalse(await Drive.exists(firstResponse.avatar.name!))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.isTrue(await Drive.exists(secondResponse.avatar.name!))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(secondResponse.avatar.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.large.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.small.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.large.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.small.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.thumbnail.url)
 
     assert.isTrue(
-      secondResponse.avatar.breakpoints!.thumbnail.size <
-        secondResponse.avatar.breakpoints!.small.size
+      secondResponse.avatar.breakpoints?.thumbnail.size! <
+        secondResponse.avatar.breakpoints?.small.size!
     )
     assert.isTrue(
-      secondResponse.avatar.breakpoints!.small.size < secondResponse.avatar.breakpoints!.medium.size
+      secondResponse.avatar.breakpoints?.small.size! <
+        secondResponse.avatar.breakpoints?.medium.size!
     )
     assert.isTrue(
-      secondResponse.avatar.breakpoints!.medium.size < secondResponse.avatar.breakpoints!.large.size
+      secondResponse.avatar.breakpoints?.medium.size! <
+        secondResponse.avatar.breakpoints?.large.size!
     )
-    assert.isTrue(secondResponse.avatar.breakpoints!.large.size < secondResponse.avatar.size!)
+    assert.isTrue(secondResponse.avatar.breakpoints?.large.size! < secondResponse.avatar.size!)
   })
 
   test('cleanup attachments when save call fails', async (assert) => {
@@ -518,22 +520,22 @@ test.group('@responsiveAttachment | update', (group) => {
     assert.deepEqual(users[0].avatar?.toJSON(), firstResponse.avatar)
 
     assert.isTrue(await Drive.exists(firstResponse.avatar.name!))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.isFalse(await Drive.exists(secondResponse.avatar.name!))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(firstResponse.avatar.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.large.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.small.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.large.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.small.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.thumbnail.url)
   })
 })
 
@@ -603,34 +605,36 @@ test.group('@responsiveAttachment | update with transaction', (group) => {
     assert.deepEqual(users[0].avatar?.toJSON(), secondResponse.avatar)
 
     assert.isFalse(await Drive.exists(firstResponse.avatar.name!))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.isTrue(await Drive.exists(secondResponse.avatar.name!))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(secondResponse.avatar.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.large.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.small.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.large.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.small.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.thumbnail.url)
 
     assert.isTrue(
-      secondResponse.avatar.breakpoints!.thumbnail.size <
-        secondResponse.avatar.breakpoints!.small.size
+      secondResponse.avatar.breakpoints?.thumbnail.size! <
+        secondResponse.avatar.breakpoints?.small.size!
     )
     assert.isTrue(
-      secondResponse.avatar.breakpoints!.small.size < secondResponse.avatar.breakpoints!.medium.size
+      secondResponse.avatar.breakpoints?.small.size! <
+        secondResponse.avatar.breakpoints?.medium.size!
     )
     assert.isTrue(
-      secondResponse.avatar.breakpoints!.medium.size < secondResponse.avatar.breakpoints!.large.size
+      secondResponse.avatar.breakpoints?.medium.size! <
+        secondResponse.avatar.breakpoints?.large.size!
     )
-    assert.isTrue(secondResponse.avatar.breakpoints!.large.size < secondResponse.avatar.size!)
+    assert.isTrue(secondResponse.avatar.breakpoints?.large.size! < secondResponse.avatar.size!)
   })
 
   test('cleanup attachments when save call fails', async (assert) => {
@@ -688,34 +692,34 @@ test.group('@responsiveAttachment | update with transaction', (group) => {
     assert.deepEqual(users[0].avatar?.toJSON(), firstResponse.avatar!)
 
     assert.isTrue(await Drive.exists(firstResponse.avatar.name!))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.isFalse(await Drive.exists(secondResponse.avatar.name!))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(firstResponse.avatar.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.large.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.small.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.large.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.small.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.thumbnail.url)
 
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.thumbnail.size <
-        firstResponse.avatar.breakpoints!.small.size
+      firstResponse.avatar.breakpoints?.thumbnail.size! <
+        firstResponse.avatar.breakpoints?.small.size!
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.small.size < firstResponse.avatar.breakpoints!.medium.size
+      firstResponse.avatar.breakpoints?.small.size! < firstResponse.avatar.breakpoints?.medium.size!
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.medium.size < firstResponse.avatar.breakpoints!.large.size
+      firstResponse.avatar.breakpoints?.medium.size! < firstResponse.avatar.breakpoints?.large.size!
     )
-    assert.isTrue(firstResponse.avatar.breakpoints!.large.size < firstResponse.avatar.size!)
+    assert.isTrue(firstResponse.avatar.breakpoints?.large.size! < firstResponse.avatar.size!)
   })
 
   test('cleanup attachments when rollback is called after success', async (assert) => {
@@ -771,34 +775,34 @@ test.group('@responsiveAttachment | update with transaction', (group) => {
     assert.deepEqual(users[0].avatar?.toJSON(), firstResponse.avatar)
 
     assert.isTrue(await Drive.exists(firstResponse.avatar.name!))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.isFalse(await Drive.exists(secondResponse.avatar.name!))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(firstResponse.avatar.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.large.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.small.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.large.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.small.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.thumbnail.url)
 
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.thumbnail.size <
-        firstResponse.avatar.breakpoints!.small.size
+      firstResponse.avatar.breakpoints?.thumbnail.size! <
+        firstResponse.avatar.breakpoints?.small.size!
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.small.size < firstResponse.avatar.breakpoints!.medium.size
+      firstResponse.avatar.breakpoints?.small.size! < firstResponse.avatar.breakpoints?.medium.size!
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.medium.size < firstResponse.avatar.breakpoints!.large.size
+      firstResponse.avatar.breakpoints?.medium.size! < firstResponse.avatar.breakpoints?.large.size!
     )
-    assert.isTrue(firstResponse.avatar.breakpoints!.large.size < firstResponse.avatar.size!)
+    assert.isTrue(firstResponse.avatar.breakpoints?.large.size! < firstResponse.avatar.size!)
   })
 })
 
@@ -862,16 +866,16 @@ test.group('@responsiveAttachment | resetToNull', (group) => {
     assert.isNull(users[0].avatar)
 
     assert.isFalse(await Drive.exists(firstResponse.avatar.name!))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(firstResponse.avatar.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.large.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.small.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.large.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.small.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.thumbnail.url)
   })
 
   test('do not remove old file when resetting to null fails', async (assert) => {
@@ -923,28 +927,28 @@ test.group('@responsiveAttachment | resetToNull', (group) => {
     assert.deepEqual(users[0].avatar?.toJSON(), firstResponse.avatar)
 
     assert.isTrue(await Drive.exists(firstResponse.avatar.name!))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(firstResponse.avatar.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.large.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.small.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.large.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.small.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.thumbnail.url)
 
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.thumbnail.size <
-        firstResponse.avatar.breakpoints!.small.size
+      firstResponse.avatar.breakpoints?.thumbnail.size! <
+        firstResponse.avatar.breakpoints?.small.size!
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.small.size < firstResponse.avatar.breakpoints!.medium.size
+      firstResponse.avatar.breakpoints?.small.size! < firstResponse.avatar.breakpoints?.medium.size!
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.medium.size < firstResponse.avatar.breakpoints!.large.size
+      firstResponse.avatar.breakpoints?.medium.size! < firstResponse.avatar.breakpoints?.large.size!
     )
-    assert.isTrue(firstResponse.avatar.breakpoints!.large.size < firstResponse.avatar.size!)
+    assert.isTrue(firstResponse.avatar.breakpoints?.large.size! < firstResponse.avatar.size!)
   })
 })
 
@@ -1011,16 +1015,16 @@ test.group('@responsiveAttachment | resetToNull with transaction', (group) => {
     assert.isNull(users[0].avatar)
 
     assert.isFalse(await Drive.exists(firstResponse.avatar.name!))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(firstResponse.avatar.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.large.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.small.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.large.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.small.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.thumbnail.url)
   })
 
   test('do not remove old file when resetting to null fails', async (assert) => {
@@ -1077,28 +1081,28 @@ test.group('@responsiveAttachment | resetToNull with transaction', (group) => {
     assert.deepEqual(users[0].avatar?.toJSON(), firstResponse.avatar)
 
     assert.isTrue(await Drive.exists(firstResponse.avatar.name!))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(firstResponse.avatar.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.large.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.small.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.large.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.small.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.thumbnail.url)
 
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.thumbnail.size <
-        firstResponse.avatar.breakpoints!.small.size
+      firstResponse.avatar.breakpoints?.thumbnail.size! <
+        firstResponse.avatar.breakpoints?.small.size!
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.small.size < firstResponse.avatar.breakpoints!.medium.size
+      firstResponse.avatar.breakpoints?.small.size! < firstResponse.avatar.breakpoints?.medium.size!
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.medium.size < firstResponse.avatar.breakpoints!.large.size
+      firstResponse.avatar.breakpoints?.medium.size! < firstResponse.avatar.breakpoints?.large.size!
     )
-    assert.isTrue(firstResponse.avatar.breakpoints!.large.size < firstResponse.avatar.size!)
+    assert.isTrue(firstResponse.avatar.breakpoints?.large.size! < firstResponse.avatar.size!)
   })
 
   test('do not remove old file when rollback was performed after success', async (assert) => {
@@ -1150,28 +1154,28 @@ test.group('@responsiveAttachment | resetToNull with transaction', (group) => {
     assert.deepEqual(users[0].avatar?.toJSON(), firstResponse.avatar)
 
     assert.isTrue(await Drive.exists(firstResponse.avatar.name!))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(firstResponse.avatar.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.large.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.small.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.large.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.small.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.thumbnail.url)
 
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.thumbnail.size <
-        firstResponse.avatar.breakpoints!.small.size
+      firstResponse.avatar.breakpoints?.thumbnail.size! <
+        firstResponse.avatar.breakpoints?.small.size!
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.small.size < firstResponse.avatar.breakpoints!.medium.size
+      firstResponse.avatar.breakpoints?.small.size! < firstResponse.avatar.breakpoints?.medium.size!
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.medium.size < firstResponse.avatar.breakpoints!.large.size
+      firstResponse.avatar.breakpoints?.medium.size! < firstResponse.avatar.breakpoints?.large.size!
     )
-    assert.isTrue(firstResponse.avatar.breakpoints!.large.size < firstResponse.avatar.size!)
+    assert.isTrue(firstResponse.avatar.breakpoints?.large.size! < firstResponse.avatar.size!)
   })
 })
 
@@ -1234,16 +1238,16 @@ test.group('@responsiveAttachment | delete', (group) => {
     assert.lengthOf(users, 0)
 
     assert.isFalse(await Drive.exists(firstResponse.avatar.name!))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(firstResponse.avatar.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.large.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.small.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.large.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.small.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.thumbnail.url)
   })
 
   test('do not delete attachment when deletion fails', async (assert) => {
@@ -1298,15 +1302,15 @@ test.group('@responsiveAttachment | delete', (group) => {
     assert.deepEqual(users[0].avatar?.toJSON(), body.avatar)
 
     assert.isTrue(await Drive.exists(body.avatar.name!))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
   })
 })
 
@@ -1368,28 +1372,28 @@ test.group('@responsiveAttachment | delete with transaction', (group) => {
     await user.useTransaction(trx).delete()
 
     assert.isTrue(await Drive.exists(firstResponse.avatar.name!))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(firstResponse.avatar.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.large.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.small.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.large.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.small.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.thumbnail.url)
 
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.thumbnail.size <
-        firstResponse.avatar.breakpoints!.small.size
+      firstResponse.avatar.breakpoints?.thumbnail.size! <
+        firstResponse.avatar.breakpoints?.small.size!
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.small.size < firstResponse.avatar.breakpoints!.medium.size
+      firstResponse.avatar.breakpoints?.small.size! < firstResponse.avatar.breakpoints?.medium.size!
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.medium.size < firstResponse.avatar.breakpoints!.large.size
+      firstResponse.avatar.breakpoints?.medium.size! < firstResponse.avatar.breakpoints?.large.size!
     )
-    assert.isTrue(firstResponse.avatar.breakpoints!.large.size < firstResponse.avatar.size!)
+    assert.isTrue(firstResponse.avatar.breakpoints?.large.size! < firstResponse.avatar.size!)
 
     await trx.commit()
 
@@ -1397,10 +1401,10 @@ test.group('@responsiveAttachment | delete with transaction', (group) => {
     assert.lengthOf(users, 0)
 
     assert.isFalse(await Drive.exists(firstResponse.avatar.name!))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
   })
 
   test('do not delete attachment when deletion fails', async (assert) => {
@@ -1450,10 +1454,10 @@ test.group('@responsiveAttachment | delete with transaction', (group) => {
       await user.useTransaction(trx).delete()
     } catch {
       assert.isTrue(await Drive.exists(body.avatar.name!))
-      assert.isTrue(await Drive.exists(body.avatar.breakpoints!.large.name))
-      assert.isTrue(await Drive.exists(body.avatar.breakpoints!.medium.name))
-      assert.isTrue(await Drive.exists(body.avatar.breakpoints!.small.name))
-      assert.isTrue(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+      assert.isTrue(await Drive.exists(body.avatar.breakpoints?.large.name!))
+      assert.isTrue(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+      assert.isTrue(await Drive.exists(body.avatar.breakpoints?.small.name!))
+      assert.isTrue(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
       await trx.rollback()
     }
@@ -1464,15 +1468,15 @@ test.group('@responsiveAttachment | delete with transaction', (group) => {
     assert.deepEqual(users[0].avatar?.toJSON(), body.avatar)
 
     assert.isTrue(await Drive.exists(body.avatar.name!))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
   })
 })
 
@@ -1546,15 +1550,15 @@ test.group('@responsiveAttachment | find', (group) => {
     assert.isDefined(body.avatar?.breakpoints?.thumbnail.url)
 
     assert.isTrue(await Drive.exists(body.avatar.name!))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
   })
 
   test('do not pre-compute when preComputeUrls is not enabled', async (assert) => {
@@ -1596,19 +1600,19 @@ test.group('@responsiveAttachment | find', (group) => {
     const user = await User.firstOrFail()
     assert.instanceOf(user.avatar, ResponsiveAttachment)
 
-    assert.isNull(user.avatar?.urls)
-    assert.isNull(body.avatar.url)
+    assert.isUndefined(user.avatar?.urls)
+    assert.isUndefined(body.avatar.url)
 
     assert.isTrue(await Drive.exists(body.avatar.name!))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
   })
 })
 
@@ -1681,15 +1685,15 @@ test.group('@responsiveAttachment | fetch', (group) => {
     assert.isDefined(body.avatar?.breakpoints?.thumbnail.url)
 
     assert.isTrue(await Drive.exists(body.avatar.name!))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
   })
 
   test('do not pre-compute when preComputeUrls is not enabled', async (assert) => {
@@ -1731,19 +1735,19 @@ test.group('@responsiveAttachment | fetch', (group) => {
     const users = await User.all()
     assert.instanceOf(users[0].avatar, ResponsiveAttachment)
 
-    assert.isNull(users[0].avatar?.urls)
-    assert.isNull(body.avatar.url)
+    assert.isUndefined(users[0].avatar?.urls)
+    assert.isUndefined(body.avatar.url)
 
     assert.isTrue(await Drive.exists(body.avatar.name!))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
   })
 })
 
@@ -1816,15 +1820,15 @@ test.group('@responsiveAttachment | paginate', (group) => {
     assert.isDefined(body.avatar?.breakpoints?.thumbnail.url)
 
     assert.isTrue(await Drive.exists(body.avatar.name!))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
   })
 
   test('do not pre-compute when preComputeUrls is not enabled', async (assert) => {
@@ -1866,19 +1870,19 @@ test.group('@responsiveAttachment | paginate', (group) => {
     const users = await User.query().paginate(1)
     assert.instanceOf(users[0].avatar, ResponsiveAttachment)
 
-    assert.isNull(users[0].avatar?.urls)
-    assert.isNull(body.avatar.url)
+    assert.isUndefined(users[0].avatar?.urls)
+    assert.isUndefined(body.avatar.url)
 
     assert.isTrue(await Drive.exists(body.avatar.name!))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
   })
 })
 
@@ -1941,22 +1945,22 @@ test.group('@responsiveAttachment | fromBuffer | insert', (group) => {
     assert.instanceOf(users[0].avatar, ResponsiveAttachment)
     assert.deepEqual(users[0].avatar?.toJSON(), body.avatar)
 
-    assert.isTrue(await Drive.exists(body.avatar.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(body.avatar.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
 
     assert.notExists(body.avatar.url)
-    assert.notExists(body.avatar.breakpoints!.large.url)
-    assert.notExists(body.avatar.breakpoints!.medium.url)
-    assert.notExists(body.avatar.breakpoints!.small.url)
-    assert.notExists(body.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(body.avatar.breakpoints?.large.url)
+    assert.notExists(body.avatar.breakpoints?.medium.url)
+    assert.notExists(body.avatar.breakpoints?.small.url)
+    assert.notExists(body.avatar.breakpoints?.thumbnail.url)
   })
 
   test('cleanup attachments when save call fails', async (assert) => {
@@ -2006,21 +2010,21 @@ test.group('@responsiveAttachment | fromBuffer | insert', (group) => {
     assert.isNull(users[0].avatar)
 
     assert.isFalse(await Drive.exists(body.avatar.name!))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
 
     assert.notExists(body.avatar.url)
-    assert.notExists(body.avatar.breakpoints!.large.url)
-    assert.notExists(body.avatar.breakpoints!.medium.url)
-    assert.notExists(body.avatar.breakpoints!.small.url)
-    assert.notExists(body.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(body.avatar.breakpoints?.large.url)
+    assert.notExists(body.avatar.breakpoints?.medium.url)
+    assert.notExists(body.avatar.breakpoints?.small.url)
+    assert.notExists(body.avatar.breakpoints?.thumbnail.url)
   })
 })
 
@@ -2088,21 +2092,21 @@ test.group('@responsiveAttachment | fromBuffer | insert with transaction', (grou
     assert.deepEqual(users[0].avatar?.toJSON(), body.avatar)
 
     assert.isTrue(await Drive.exists(body.avatar.name!))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
 
     assert.notExists(body.avatar.url)
-    assert.notExists(body.avatar.breakpoints!.large.url)
-    assert.notExists(body.avatar.breakpoints!.medium.url)
-    assert.notExists(body.avatar.breakpoints!.small.url)
-    assert.notExists(body.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(body.avatar.breakpoints?.large.url)
+    assert.notExists(body.avatar.breakpoints?.medium.url)
+    assert.notExists(body.avatar.breakpoints?.small.url)
+    assert.notExists(body.avatar.breakpoints?.thumbnail.url)
   })
 
   test('cleanup attachments when save call fails', async (assert) => {
@@ -2157,21 +2161,21 @@ test.group('@responsiveAttachment | fromBuffer | insert with transaction', (grou
     assert.isNull(users[0].avatar)
 
     assert.isFalse(await Drive.exists(body.avatar.name!))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
-    assert.isTrue(body.avatar.breakpoints!.thumbnail.size < body.avatar.breakpoints!.small.size)
-    assert.isTrue(body.avatar.breakpoints!.small.size < body.avatar.breakpoints!.medium.size)
-    assert.isTrue(body.avatar.breakpoints!.medium.size < body.avatar.breakpoints!.large.size)
-    assert.isTrue(body.avatar.breakpoints!.large.size < body.avatar.size!)
+    assert.isTrue(body.avatar.breakpoints?.thumbnail.size! < body.avatar.breakpoints?.small.size!)
+    assert.isTrue(body.avatar.breakpoints?.small.size! < body.avatar.breakpoints?.medium.size!)
+    assert.isTrue(body.avatar.breakpoints?.medium.size! < body.avatar.breakpoints?.large.size!)
+    assert.isTrue(body.avatar.breakpoints?.large.size! < body.avatar.size!)
 
     assert.notExists(body.avatar.url)
-    assert.notExists(body.avatar.breakpoints!.large.url)
-    assert.notExists(body.avatar.breakpoints!.medium.url)
-    assert.notExists(body.avatar.breakpoints!.small.url)
-    assert.notExists(body.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(body.avatar.breakpoints?.large.url)
+    assert.notExists(body.avatar.breakpoints?.medium.url)
+    assert.notExists(body.avatar.breakpoints?.small.url)
+    assert.notExists(body.avatar.breakpoints?.thumbnail.url)
   })
 
   test('cleanup attachments when rollback is called after success', async (assert) => {
@@ -2217,16 +2221,16 @@ test.group('@responsiveAttachment | fromBuffer | insert with transaction', (grou
 
     assert.lengthOf(users, 0)
     assert.isFalse(await Drive.exists(body.avatar.name!))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(body.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(body.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(body.avatar.url)
-    assert.notExists(body.avatar.breakpoints!.large.url)
-    assert.notExists(body.avatar.breakpoints!.medium.url)
-    assert.notExists(body.avatar.breakpoints!.small.url)
-    assert.notExists(body.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(body.avatar.breakpoints?.large.url)
+    assert.notExists(body.avatar.breakpoints?.medium.url)
+    assert.notExists(body.avatar.breakpoints?.small.url)
+    assert.notExists(body.avatar.breakpoints?.thumbnail.url)
   })
 })
 
@@ -2291,34 +2295,36 @@ test.group('@responsiveAttachment | fromBuffer | update', (group) => {
     assert.deepEqual(users[0].avatar?.toJSON(), secondResponse.avatar)
 
     assert.isFalse(await Drive.exists(firstResponse.avatar.name!))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.isTrue(await Drive.exists(secondResponse.avatar.name!))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(secondResponse.avatar.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.large.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.small.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.large.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.small.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.thumbnail.url)
 
     assert.isTrue(
-      secondResponse.avatar.breakpoints!.thumbnail.size <
-        secondResponse.avatar.breakpoints!.small.size
+      secondResponse.avatar.breakpoints?.thumbnail.size! <
+        secondResponse.avatar.breakpoints?.small.size
     )
     assert.isTrue(
-      secondResponse.avatar.breakpoints!.small.size < secondResponse.avatar.breakpoints!.medium.size
+      secondResponse.avatar.breakpoints?.small.size! <
+        secondResponse.avatar.breakpoints?.medium.size
     )
     assert.isTrue(
-      secondResponse.avatar.breakpoints!.medium.size < secondResponse.avatar.breakpoints!.large.size
+      secondResponse.avatar.breakpoints?.medium.size! <
+        secondResponse.avatar.breakpoints?.large.size
     )
-    assert.isTrue(secondResponse.avatar.breakpoints!.large.size < secondResponse.avatar.size!)
+    assert.isTrue(secondResponse.avatar.breakpoints?.large.size! < secondResponse.avatar.size!)
   })
 
   test('cleanup attachments when save call fails', async (assert) => {
@@ -2369,22 +2375,22 @@ test.group('@responsiveAttachment | fromBuffer | update', (group) => {
     assert.deepEqual(users[0].avatar?.toJSON(), firstResponse.avatar)
 
     assert.isTrue(await Drive.exists(firstResponse.avatar.name!))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.isFalse(await Drive.exists(secondResponse.avatar.name!))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(firstResponse.avatar.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.large.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.small.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.large.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.small.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.thumbnail.url)
   })
 })
 
@@ -2452,34 +2458,36 @@ test.group('@responsiveAttachment | fromBuffer | update with transaction', (grou
     assert.deepEqual(users[0].avatar?.toJSON(), secondResponse.avatar)
 
     assert.isFalse(await Drive.exists(firstResponse.avatar.name!))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.isTrue(await Drive.exists(secondResponse.avatar.name!))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(secondResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(secondResponse.avatar.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.large.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.small.url)
-    assert.notExists(secondResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.large.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.small.url)
+    assert.notExists(secondResponse.avatar.breakpoints?.thumbnail.url)
 
     assert.isTrue(
-      secondResponse.avatar.breakpoints!.thumbnail.size <
-        secondResponse.avatar.breakpoints!.small.size
+      secondResponse.avatar.breakpoints?.thumbnail.size! <
+        secondResponse.avatar.breakpoints?.small.size
     )
     assert.isTrue(
-      secondResponse.avatar.breakpoints!.small.size < secondResponse.avatar.breakpoints!.medium.size
+      secondResponse.avatar.breakpoints?.small.size! <
+        secondResponse.avatar.breakpoints?.medium.size
     )
     assert.isTrue(
-      secondResponse.avatar.breakpoints!.medium.size < secondResponse.avatar.breakpoints!.large.size
+      secondResponse.avatar.breakpoints?.medium.size! <
+        secondResponse.avatar.breakpoints?.large.size
     )
-    assert.isTrue(secondResponse.avatar.breakpoints!.large.size < secondResponse.avatar.size!)
+    assert.isTrue(secondResponse.avatar.breakpoints?.large.size! < secondResponse.avatar.size!)
   })
 
   test('cleanup attachments when save call fails', async (assert) => {
@@ -2535,34 +2543,34 @@ test.group('@responsiveAttachment | fromBuffer | update with transaction', (grou
     assert.deepEqual(users[0].avatar?.toJSON(), firstResponse.avatar)
 
     assert.isTrue(await Drive.exists(firstResponse.avatar.name!))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.isFalse(await Drive.exists(secondResponse.avatar.name!))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(firstResponse.avatar.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.large.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.small.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.large.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.small.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.thumbnail.url)
 
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.thumbnail.size <
-        firstResponse.avatar.breakpoints!.small.size
+      firstResponse.avatar.breakpoints?.thumbnail.size! <
+        firstResponse.avatar.breakpoints?.small.size
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.small.size < firstResponse.avatar.breakpoints!.medium.size
+      firstResponse.avatar.breakpoints?.small.size! < firstResponse.avatar.breakpoints?.medium.size
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.medium.size < firstResponse.avatar.breakpoints!.large.size
+      firstResponse.avatar.breakpoints?.medium.size! < firstResponse.avatar.breakpoints?.large.size
     )
-    assert.isTrue(firstResponse.avatar.breakpoints!.large.size < firstResponse.avatar.size!)
+    assert.isTrue(firstResponse.avatar.breakpoints?.large.size! < firstResponse.avatar.size!)
   })
 
   test('cleanup attachments when rollback is called after success', async (assert) => {
@@ -2606,7 +2614,6 @@ test.group('@responsiveAttachment | fromBuffer | update with transaction', (grou
     })
 
     const { body: firstResponse } = await supertest(server).post('/')
-
     const { body: secondResponse } = await supertest(server).post('/')
 
     const users = await User.all()
@@ -2616,33 +2623,33 @@ test.group('@responsiveAttachment | fromBuffer | update with transaction', (grou
     assert.deepEqual(users[0].avatar?.toJSON(), firstResponse.avatar)
 
     assert.isTrue(await Drive.exists(firstResponse.avatar.name!))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.large.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.medium.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.small.name))
-    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.large.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.medium.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.small.name!))
+    assert.isTrue(await Drive.exists(firstResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.isFalse(await Drive.exists(secondResponse.avatar.name!))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.large.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.medium.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.small.name))
-    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints!.thumbnail.name))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.large.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.medium.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.small.name!))
+    assert.isFalse(await Drive.exists(secondResponse.avatar.breakpoints?.thumbnail.name!))
 
     assert.notExists(firstResponse.avatar.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.large.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.medium.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.small.url)
-    assert.notExists(firstResponse.avatar.breakpoints!.thumbnail.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.large.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.medium.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.small.url)
+    assert.notExists(firstResponse.avatar.breakpoints?.thumbnail.url)
 
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.thumbnail.size <
-        firstResponse.avatar.breakpoints!.small.size
+      firstResponse.avatar.breakpoints?.thumbnail.size! <
+        firstResponse.avatar.breakpoints?.small.size
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.small.size < firstResponse.avatar.breakpoints!.medium.size
+      firstResponse.avatar.breakpoints?.small.size! < firstResponse.avatar.breakpoints?.medium.size
     )
     assert.isTrue(
-      firstResponse.avatar.breakpoints!.medium.size < firstResponse.avatar.breakpoints!.large.size
+      firstResponse.avatar.breakpoints?.medium.size! < firstResponse.avatar.breakpoints?.large.size
     )
-    assert.isTrue(firstResponse.avatar.breakpoints!.large.size < firstResponse.avatar.size!)
+    assert.isTrue(firstResponse.avatar.breakpoints?.large.size! < firstResponse.avatar.size!)
   })
 })


### PR DESCRIPTION
## Proposed changes

The `keepOriginal` option allows you to decide whether to keep the original uploaded image or not. If you do not have any need for the original image in the future, there should be no need to keep it. By default `keepOriginal` is `true` but you can disable it by setting it to `false`.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/attachment-lite/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Related Issues: