### PR TITLE
Digiital ocean space error

### DIFF
--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -79,9 +79,9 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
       extname: file.extname!,
       mimeType: `${file.type}/${file.subtype}`,
       size: file.size,
-      path: file.filePath,
+      path: file.fileName,
     }
-
+ 
     return new ResponsiveAttachment(attributes) as ResponsiveAttachmentContract
   }
 


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes
Using `filePath` when drive is digital ocean `spaces` catch a error when drive try to get file, because filePath is a full url not dir path. Change for `fileName` will get a file path correctly


## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/adonisjs/attachment-lite/blob/master/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
