### PR TITLE
fix(attachment): do not use absolute path to retrieve file

### DIFF
--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -37,7 +37,7 @@ import {
 import { merge, isEmpty, assign, set } from 'lodash'
 import { DEFAULT_BREAKPOINTS } from './decorator'
 
-export const kUploadFolder = 'image_upload_tmp'
+export const tempUploadFolder = 'image_upload_tmp'
 
 /**
  * Attachment class represents an attachment data type
@@ -70,7 +70,7 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
     }
     // Store the file locally first and add the path to the ImageInfo
     // This will be removed after the operation is completed
-    await file.moveToDisk(kUploadFolder)
+    await file.moveToDisk(tempUploadFolder)
 
     if (allowedFormats.includes(file?.subtype as AttachmentOptions['forceFormat']) === false) {
       throw new RangeError(
@@ -258,9 +258,9 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
     this.isLocal = !!this.path || !!this.buffer
 
     if (attributes.fileName) {
-      this.relativePath = join(kUploadFolder, attributes.fileName)
+      this.relativePath = join(tempUploadFolder, attributes.fileName)
     } else if (attributes.name) {
-      this.relativePath = join(kUploadFolder, attributes.name)
+      this.relativePath = join(tempUploadFolder, attributes.name)
     } else {
       this.relativePath = ''
     }

--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -9,7 +9,7 @@
 
 /// <reference path="../../adonis-typings/index.ts" />
 
-import { join } from 'node:path'
+import { join } from 'path'
 import { Exception } from '@poppinss/utils'
 import { cuid } from '@poppinss/utils/build/helpers'
 import detect from 'detect-file-type'

--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -9,6 +9,7 @@
 
 /// <reference path="../../adonis-typings/index.ts" />
 
+import { join } from 'node:path'
 import { Exception } from '@poppinss/utils'
 import { cuid } from '@poppinss/utils/build/helpers'
 import detect from 'detect-file-type'
@@ -35,6 +36,8 @@ import {
 } from '../Helpers/ImageManipulationHelper'
 import { merge, isEmpty, assign, set } from 'lodash'
 import { DEFAULT_BREAKPOINTS } from './decorator'
+
+export const kUploadFolder = 'image_upload_tmp'
 
 /**
  * Attachment class represents an attachment data type
@@ -67,7 +70,7 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
     }
     // Store the file locally first and add the path to the ImageInfo
     // This will be removed after the operation is completed
-    await file.moveToDisk('image_upload_tmp')
+    await file.moveToDisk(kUploadFolder)
 
     if (allowedFormats.includes(file?.subtype as AttachmentOptions['forceFormat']) === false) {
       throw new RangeError(
@@ -80,6 +83,7 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
       mimeType: `${file.type}/${file.subtype}`,
       size: file.size,
       path: file.filePath,
+      fileName: file.fileName,
     }
 
     return new ResponsiveAttachment(attributes) as ResponsiveAttachmentContract
@@ -200,6 +204,16 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
   public height?: number
 
   /**
+   * This file name.
+   */
+  public fileName?: string
+
+  /**
+   * The relative path from the disk.
+   */
+  public relativePath?: string
+
+  /**
    * The absolute path of the original uploaded file
    * Available after initial move operation in the decorator
    */
@@ -225,7 +239,10 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
    */
   public isDeleted: boolean
 
-  constructor(attributes: AttachmentAttributes, private buffer?: Buffer | null) {
+  constructor(
+    attributes: AttachmentAttributes & { fileName?: string },
+    private buffer?: Buffer | null
+  ) {
     this.name = attributes.name
     this.size = attributes.size
     this.hash = attributes.hash
@@ -236,8 +253,17 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
     this.mimeType = attributes.mimeType
     this.url = attributes.url ?? undefined
     this.breakpoints = attributes.breakpoints ?? undefined
+    this.fileName = attributes.fileName ?? ''
     this.path = attributes.path ?? ''
     this.isLocal = !!this.path || !!this.buffer
+
+    if (attributes.fileName) {
+      this.relativePath = join(kUploadFolder, attributes.fileName)
+    } else if (attributes.name) {
+      this.relativePath = join(kUploadFolder, attributes.name)
+    } else {
+      this.relativePath = ''
+    }
   }
 
   public get attributes() {
@@ -292,7 +318,7 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
 
   protected async enhanceFile(): Promise<ImageInfo> {
     // Read the image as a buffer using `Drive.get()`
-    const originalFileBuffer = this.buffer ?? (await this.getDisk().get(this.path!))
+    const originalFileBuffer = this.buffer ?? (await this.getDisk().get(this.relativePath!))
 
     // Optimise the image buffer and return the optimised buffer
     // and the info of the image

--- a/test/attachment.spec.ts
+++ b/test/attachment.spec.ts
@@ -9,15 +9,15 @@
 
 import 'reflect-metadata'
 
+import { join } from 'node:path'
 import test from 'japa'
-import { join } from 'path'
 import supertest from 'supertest'
 import { createServer } from 'http'
 import { ApplicationContract } from '@ioc:Adonis/Core/Application'
 import { BodyParserMiddleware } from '@adonisjs/bodyparser/build/src/BodyParser'
 import { getDimensions } from '../src/Helpers/ImageManipulationHelper'
 
-import { ResponsiveAttachment } from '../src/Attachment'
+import { kUploadFolder, ResponsiveAttachment } from '../src/Attachment'
 import { setup, cleanup, setupApplication } from '../test-helpers'
 import { readFile } from 'fs/promises'
 
@@ -429,8 +429,8 @@ test.group('ImageManipulationHelper', (group) => {
       const ctx = app.container.resolveBinding('Adonis/Core/HttpContext').create('/', {}, req, res)
       app.container.make(BodyParserMiddleware).handle(ctx, async () => {
         const file = ctx.request.file('avatar')!
-        await file.moveToDisk('image_upload_tmp')
-        const buffer = await Drive.get(file.filePath!)
+        await file.moveToDisk(kUploadFolder)
+        const buffer = await Drive.get(join(kUploadFolder, file.fileName!))
         const { width, height } = await getDimensions(buffer)
 
         assert.equal(width, 1500)

--- a/test/attachment.spec.ts
+++ b/test/attachment.spec.ts
@@ -9,8 +9,8 @@
 
 import 'reflect-metadata'
 
-import { join } from 'node:path'
 import test from 'japa'
+import { join } from 'path'
 import supertest from 'supertest'
 import { createServer } from 'http'
 import { ApplicationContract } from '@ioc:Adonis/Core/Application'

--- a/test/attachment.spec.ts
+++ b/test/attachment.spec.ts
@@ -17,7 +17,7 @@ import { ApplicationContract } from '@ioc:Adonis/Core/Application'
 import { BodyParserMiddleware } from '@adonisjs/bodyparser/build/src/BodyParser'
 import { getDimensions } from '../src/Helpers/ImageManipulationHelper'
 
-import { kUploadFolder, ResponsiveAttachment } from '../src/Attachment'
+import { tempUploadFolder, ResponsiveAttachment } from '../src/Attachment'
 import { setup, cleanup, setupApplication } from '../test-helpers'
 import { readFile } from 'fs/promises'
 
@@ -429,8 +429,8 @@ test.group('ImageManipulationHelper', (group) => {
       const ctx = app.container.resolveBinding('Adonis/Core/HttpContext').create('/', {}, req, res)
       app.container.make(BodyParserMiddleware).handle(ctx, async () => {
         const file = ctx.request.file('avatar')!
-        await file.moveToDisk(kUploadFolder)
-        const buffer = await Drive.get(join(kUploadFolder, file.fileName!))
+        await file.moveToDisk(tempUploadFolder)
+        const buffer = await Drive.get(join(tempUploadFolder, file.fileName!))
         const { width, height } = await getDimensions(buffer)
 
         assert.equal(width, 1500)


### PR DESCRIPTION
Hey there! 👋🏻 

The test wasn't going through on my machine.
Because of a `Drive` update to avoid path traversal vulnerability, we must avoid using absolute path when using `Drive` API.

This PR generates a relative path for the asset and makes tests pass again.