### PR TITLE
Changing join function to remove '\\' from paths

### DIFF
--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -9,6 +9,7 @@
 
 /// <reference path="../../adonis-typings/index.ts" />
 
+import { join } from 'path'
 import { Exception } from '@poppinss/utils'
 import { cuid } from '@poppinss/utils/build/helpers'
 import detect from 'detect-file-type'

--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -258,9 +258,9 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
     this.isLocal = !!this.path || !!this.buffer
 
     if (attributes.fileName) {
-      this.relativePath = join(tempUploadFolder, attributes.fileName)
+      this.relativePath = tempUploadFolder + attributes.fileName
     } else if (attributes.name) {
-      this.relativePath = join(tempUploadFolder, attributes.name)
+      this.relativePath = tempUploadFolder + attributes.name
     } else {
       this.relativePath = ''
     }

--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -9,7 +9,7 @@
 
 /// <reference path="../../adonis-typings/index.ts" />
 
-import { join } from 'path'
+import { join, normalize } from 'path'
 import { Exception } from '@poppinss/utils'
 import { cuid } from '@poppinss/utils/build/helpers'
 import detect from 'detect-file-type'
@@ -319,7 +319,7 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
   protected async enhanceFile(): Promise<ImageInfo> {
     // Read the image as a buffer using `Drive.get()`, normalizing the path
     const originalFileBuffer =
-      this.buffer ?? (await this.getDisk().get(this.relativePath!.replace(/\\/g, '/')))
+      this.buffer ?? (await this.getDisk().get(normalize(this.relativePath!)))
     // Optimise the image buffer and return the optimised buffer
     // and the info of the image
     const { buffer, info } = await optimize(originalFileBuffer, this.options)

--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -317,9 +317,9 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
   }
 
   protected async enhanceFile(): Promise<ImageInfo> {
-    // Read the image as a buffer using `Drive.get()`
-    const originalFileBuffer = this.buffer ?? (await this.getDisk().get(this.relativePath!))
-
+    // Read the image as a buffer using `Drive.get()`, normalizing the path
+    const originalFileBuffer =
+      this.buffer ?? (await this.getDisk().get(this.relativePath!.replace(/\\/g, '/')))
     // Optimise the image buffer and return the optimised buffer
     // and the info of the image
     const { buffer, info } = await optimize(originalFileBuffer, this.options)

--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -9,7 +9,6 @@
 
 /// <reference path="../../adonis-typings/index.ts" />
 
-import { join } from 'path'
 import { Exception } from '@poppinss/utils'
 import { cuid } from '@poppinss/utils/build/helpers'
 import detect from 'detect-file-type'

--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -258,9 +258,9 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
     this.isLocal = !!this.path || !!this.buffer
 
     if (attributes.fileName) {
-      this.relativePath = tempUploadFolder + attributes.fileName
+      this.relativePath = join(tempUploadFolder, attributes.fileName)
     } else if (attributes.name) {
-      this.relativePath = tempUploadFolder + attributes.name
+      this.relativePath = join(tempUploadFolder, attributes.name)
     } else {
       this.relativePath = ''
     }


### PR DESCRIPTION
## Proposed changes

The join function in TS sometime use ```\\``` to create path, and Digital Ocean Space's doesn't recognize any path with it. Change the join function to a concatenation work properly.

This is to fix #11 