### PR TITLE
Allow gif and svg to be uploaded

### DIFF
--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -85,7 +85,7 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
 
     if (allowedFormats.includes(file?.subtype as AttachmentOptions['forceFormat']) === false) {
       throw new RangeError(
-        `Uploaded file is not an allowable image. Make sure that you uploaded only the following format: "jpeg", "png", "webp", "tiff", and "avif".`
+        `Uploaded file is not an allowable image. Make sure that you uploaded only the following format: "jpeg", "png", "webp", "tiff", "avif", "gif" and "svg".`
       )
     }
 
@@ -133,7 +133,7 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
 
         if (allowedFormats.includes(subtype as AttachmentOptions['forceFormat']) === false) {
           throw new RangeError(
-            `Uploaded file is not an allowable image. Make sure that you uploaded only the following format: "jpeg", "png", "webp", "tiff", and "avif".`
+            `Uploaded file is not an allowable image. Make sure that you uploaded only the following format: "jpeg", "png", "webp", "tiff", "avif", "gif" and "svg".`
           )
         }
 

--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -18,6 +18,7 @@ import { LoggerContract } from '@ioc:Adonis/Core/Logger'
 import type { MultipartFileContract } from '@ioc:Adonis/Core/BodyParser'
 import { DriveManagerContract, ContentHeaders, Visibility } from '@ioc:Adonis/Core/Drive'
 import {
+  AllowedFormats,
   allowedFormats,
   generateBreakpointImages,
   generateName,
@@ -83,7 +84,7 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
       throw new SyntaxError('You should provide a non-falsy value')
     }
 
-    if (allowedFormats.includes(file?.subtype as AttachmentOptions['forceFormat']) === false) {
+    if (allowedFormats.includes(file?.subtype as AllowedFormats) === false) {
       throw new RangeError(
         `Uploaded file is not an allowable image. Make sure that you uploaded only the following format: "jpeg", "png", "webp", "tiff", "avif", "gif" and "svg".`
       )
@@ -131,7 +132,7 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
         const { mime, ext } = bufferProperty!
         const subtype = mime.split('/').pop()
 
-        if (allowedFormats.includes(subtype as AttachmentOptions['forceFormat']) === false) {
+        if (allowedFormats.includes(subtype as AllowedFormats) === false) {
           throw new RangeError(
             `Uploaded file is not an allowable image. Make sure that you uploaded only the following format: "jpeg", "png", "webp", "tiff", "avif", "gif" and "svg".`
           )

--- a/src/Helpers/ImageManipulationHelper.ts
+++ b/src/Helpers/ImageManipulationHelper.ts
@@ -67,7 +67,7 @@ export const resizeTo = async function (
 export const breakpointSmallerThan = (breakpoint: number, { width, height }: FileDimensions) =>
   breakpoint < width! || breakpoint < height!
 
-type AllowedFormats = 'jpeg' | 'png' | 'webp' | 'avif' | 'tiff' | 'gif' | 'svg' | 'svg+xml'
+export type AllowedFormats = 'jpeg' | 'png' | 'webp' | 'avif' | 'tiff' | 'gif' | 'svg' | 'svg+xml'
 
 // Image formats you can upload
 export const allowedFormats: Array<AllowedFormats> = [

--- a/src/Helpers/ImageManipulationHelper.ts
+++ b/src/Helpers/ImageManipulationHelper.ts
@@ -67,17 +67,26 @@ export const resizeTo = async function (
 export const breakpointSmallerThan = (breakpoint: number, { width, height }: FileDimensions) =>
   breakpoint < width! || breakpoint < height!
 
-export const allowedFormats: Array<AttachmentOptions['forceFormat']> = [
+type AllowedFormats = 'jpeg' | 'png' | 'webp' | 'avif' | 'tiff' | 'gif' | 'svg' | 'svg+xml'
+
+// Image formats you can upload
+export const allowedFormats: Array<AllowedFormats> = [
   'jpeg',
   'png',
   'webp',
   'avif',
   'tiff',
+  'gif',
+  'svg',
+  'svg+xml',
 ]
+
+// Formats we want to be safely processed by sharp
+export const conversionFormats: Array<AllowedFormats> = ['jpeg', 'png', 'webp', 'avif', 'tiff']
 
 export const canBeProcessed = async (buffer: Buffer) => {
   const { format } = await getMetaData(buffer)
-  return format && allowedFormats.includes(format as AttachmentOptions['forceFormat'])
+  return format && conversionFormats.includes(format as AllowedFormats)
 }
 
 const getImageExtension = function (imageFormat: ImageInfo['format']) {

--- a/test/attachment.spec.ts
+++ b/test/attachment.spec.ts
@@ -1273,7 +1273,7 @@ test.group('ResponsiveAttachment | errors', (group) => {
         } catch (error) {
           assert.equal(
             error.message,
-            `Uploaded file is not an allowable image. Make sure that you uploaded only the following format: "jpeg", "png", "webp", "tiff", and "avif".`
+            `Uploaded file is not an allowable image. Make sure that you uploaded only the following format: "jpeg", "png", "webp", "tiff", "avif", "gif" and "svg".`
           )
           ctx.response.send(error)
           ctx.response.finish()
@@ -1298,7 +1298,7 @@ test.group('ResponsiveAttachment | errors', (group) => {
         } catch (error) {
           assert.equal(
             error.message,
-            `Uploaded file is not an allowable image. Make sure that you uploaded only the following format: "jpeg", "png", "webp", "tiff", and "avif".`
+            `Uploaded file is not an allowable image. Make sure that you uploaded only the following format: "jpeg", "png", "webp", "tiff", "avif", "gif" and "svg".`
           )
           ctx.response.send(error)
           ctx.response.finish()


### PR DESCRIPTION
Allows gif and svg to be uploaded without being converted by sharp for breakpoints and thumbnails.

I'm running this on several projects with no problems.