### PR TITLE
Return_attachment_instance_on_save_if_already_persisted

### DIFF
--- a/src/Attachment/index.ts
+++ b/src/Attachment/index.ts
@@ -368,7 +368,7 @@ export class ResponsiveAttachment implements ResponsiveAttachmentContract {
        * instance is not local
        */
       if (!this.isLocal || this.isPersisted) {
-        return
+        return this
       }
 
       /**

--- a/src/Bindings/Validator.ts
+++ b/src/Bindings/Validator.ts
@@ -29,7 +29,7 @@ enum ImageDimensionsValidationRule {
  * Ensure image is complaint with expected dimensions validations
  */
 class ImageDimensionsCheck {
-  constructor (public ruleName: ImageDimensionsValidationRule, protected logger: LoggerContract) { }
+  constructor(public ruleName: ImageDimensionsValidationRule, protected logger: LoggerContract) {}
 
   /**
    * Compile validation options
@@ -70,7 +70,8 @@ class ImageDimensionsCheck {
         pointer,
         this.ruleName,
         `${this.ruleName} validation failure`,
-        arrayExpressionPointer, { [this.ruleName]: validationValue }
+        arrayExpressionPointer,
+        { [this.ruleName]: validationValue }
       )
     }
 
@@ -145,7 +146,8 @@ export function extendValidator(validator: typeof validatorStatic, logger: Logge
           options.pointer,
           `${minImageWidthRuleChecker.ruleName}`,
           `${minImageWidthRuleChecker.ruleName} validation failure`,
-          options.arrayExpressionPointer, { [minImageWidthRuleChecker.ruleName]: compiledOptions.validationValue }
+          options.arrayExpressionPointer,
+          { [minImageWidthRuleChecker.ruleName]: compiledOptions.validationValue }
         )
       }
     },
@@ -178,7 +180,8 @@ export function extendValidator(validator: typeof validatorStatic, logger: Logge
           options.pointer,
           `${minImageHeightRuleChecker.ruleName}`,
           `${minImageHeightRuleChecker.ruleName} validation failure`,
-          options.arrayExpressionPointer, { [minImageHeightRuleChecker.ruleName]: compiledOptions.validationValue }
+          options.arrayExpressionPointer,
+          { [minImageHeightRuleChecker.ruleName]: compiledOptions.validationValue }
         )
       }
     },
@@ -211,7 +214,8 @@ export function extendValidator(validator: typeof validatorStatic, logger: Logge
           options.pointer,
           `${maxImageWidthRuleChecker.ruleName}`,
           `${maxImageWidthRuleChecker.ruleName} validation failure`,
-          options.arrayExpressionPointer, { [maxImageWidthRuleChecker.ruleName]: compiledOptions.validationValue }
+          options.arrayExpressionPointer,
+          { [maxImageWidthRuleChecker.ruleName]: compiledOptions.validationValue }
         )
       }
     },
@@ -244,7 +248,8 @@ export function extendValidator(validator: typeof validatorStatic, logger: Logge
           options.pointer,
           `${maxImageHeightRuleChecker.ruleName}`,
           `${maxImageHeightRuleChecker.ruleName} validation failure`,
-          options.arrayExpressionPointer, { [maxImageHeightRuleChecker.ruleName]: compiledOptions.validationValue }
+          options.arrayExpressionPointer,
+          { [maxImageHeightRuleChecker.ruleName]: compiledOptions.validationValue }
         )
       }
     },
@@ -274,7 +279,8 @@ export function extendValidator(validator: typeof validatorStatic, logger: Logge
           options.pointer,
           `${aspectRatioRuleChecker.ruleName}`,
           `${aspectRatioRuleChecker.ruleName} validation failure`,
-          options.arrayExpressionPointer, { [aspectRatioRuleChecker.ruleName]: compiledOptions.validationValue }
+          options.arrayExpressionPointer,
+          { [aspectRatioRuleChecker.ruleName]: compiledOptions.validationValue }
         )
       }
     },


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

This PR instance the `save` method of the `ResponsiveAttachment` class to return the instance of the class if the instance is local or already persisted. This ensures that the column which the attachment is assigned to is not `undefined`.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/attachment-lite/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
