### PR TITLE
fix: improvements to `attachment.setOptions` method

### DIFF
--- a/adonis-typings/attachment.ts
+++ b/adonis-typings/attachment.ts
@@ -143,9 +143,15 @@ declare module '@ioc:Adonis/Addons/ResponsiveAttachment' {
     isDeleted: boolean
 
     /**
-     * Define persistance options
+     * Define persistence options
      */
     setOptions(options?: AttachmentOptions): this
+
+    /**
+     * Get current state of attachment options within a responsive
+     * attachment instance
+     */
+    readonly getOptions: AttachmentOptions
 
     /**
      * Save responsive images to the disk. Results if noop when "this.isLocal = false"

--- a/src/Attachment/decorator.ts
+++ b/src/Attachment/decorator.ts
@@ -52,7 +52,7 @@ async function persistAttachment(
    * remove the existing file.
    */
   if (existingFile && !newFile) {
-    existingFile.setOptions(merge(options, existingFile.options))
+    existingFile.setOptions(merge(options, existingFile.getOptions))
     modelInstance['attachments'].detached.push(existingFile)
     return
   }
@@ -62,14 +62,14 @@ async function persistAttachment(
    * file.
    */
   if (newFile && newFile.isLocal) {
-    newFile.setOptions(merge(options, newFile.options))
+    newFile.setOptions(merge(options, newFile.getOptions))
     modelInstance['attachments'].attached.push(newFile)
 
     /**
      * If there was an existing file, then we must get rid of it
      */
-    if (existingFile && !newFile.options?.persistentFileNames) {
-      existingFile.setOptions(merge(options, newFile.options))
+    if (existingFile && !newFile.getOptions?.persistentFileNames) {
+      existingFile.setOptions(merge(options, newFile.getOptions))
       modelInstance['attachments'].detached.push(existingFile)
     }
 


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

This PR improves the behaviour of the `setOptions` method of the `Attachment` instance by ensuring it doesn't set default options.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/attachment-lite/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
